### PR TITLE
Using more direct copy logic to prevent expensive deepcopy calls

### DIFF
--- a/finch/brush.py
+++ b/finch/brush.py
@@ -29,6 +29,15 @@ class Brush:
     angle           : float
     size            : int
 
+    def copy( self ) -> "Brush":
+        return Brush(
+            color=self.color,
+            texture_index=self.texture_index,
+            position=self.position.copy(),
+            angle=self.angle,
+            size=self.size,
+        )
+
 
 def str_to_brush_set( s : str ) -> BrushSet:
     return {

--- a/finch/primitive_types.py
+++ b/finch/primitive_types.py
@@ -10,6 +10,9 @@ class Point :
     x: int
     y: int
 
+    def copy( self ) -> "Point":
+        return Point( self.x, self.y )
+
 
 FitnessScore = float
 Image = np.ndarray

--- a/finch/run.py
+++ b/finch/run.py
@@ -1,4 +1,3 @@
-import copy
 import logging
 
 from datetime import datetime
@@ -154,13 +153,13 @@ def run_finch_generator(
 
     result_frames = []
     if MAKE_GIF:
-        result_frames.append( copy.deepcopy( specimen.cached_image ) )
+        result_frames.append( specimen.cached_image.copy() )
 
     while True:
         generation_index += 1
 
         # Mutate a copy of the specimen
-        new_specimen = copy.deepcopy(specimen)
+        new_specimen = specimen.copy()
         mutate_specimen_inplace(
             specimen = new_specimen,
             fitness = fitness,
@@ -195,7 +194,7 @@ def run_finch_generator(
             write_results( report_string, specimen.cached_image, specimen )
             last_written_score = rounded_score
             if MAKE_GIF:
-                result_frames.append( copy.deepcopy( specimen.cached_image ) )
+                result_frames.append( specimen.cached_image.copy() )
 
         # If ran out of patience, write the final result, and break
         ran_out_of_patience = n_iterations_with_same_score == N_ITERATIONS_PATIENCE
@@ -211,7 +210,7 @@ def run_finch_generator(
     # make sure to include the last frame in the GIF,
     # even though it did not meet the score_interval
     if MAKE_GIF :
-        result_frames.append( copy.deepcopy( specimen.cached_image ) )
+        result_frames.append( specimen.cached_image.copy() )
 
     end_time = datetime.now()
     convergence_time = end_time - start_time

--- a/finch/specimen.py
+++ b/finch/specimen.py
@@ -15,3 +15,9 @@ class Specimen :
     # and to later redraw the image with different settings, if pickled.
     # For that, see common.redraw.redraw_painting
     brushes: list[ Brush ] = field( default_factory = list )
+
+    def copy( self ) -> "Specimen":
+        return Specimen(
+            cached_image=self.cached_image.copy(),
+            brushes=[ brush.copy() for brush in self.brushes ]
+        )


### PR DESCRIPTION
While experimenting with a "continuous" version of Drarwing (I'll offer that as a PR once I have something less hacky), I found out that virtually all time is spent in `copy.deepcopy()`. As `ndarray` has an efficient copy method, and the `Brush` type is made up of primitive types (or objects that only contain primitives), we can use or create simpler copy mechanisms and prevent the expensive `deepcopy()` calls. At least for me locally, this is an immense performance gain. It stays more or less constant as time goes on, where the current version starts slowing down rapidly.

Note that I made these changes on a separate branch, so it may not work first try. Either way, it should give you a fun direction to work in if you want to try and speed things up.